### PR TITLE
feat: add AllowDisableDolbyAtoms support for ZUXOS(Android 16)

### DIFF
--- a/app/src/main/java/xyz/cirno/unfuckzui/feature/AllowDisableDolbyAtmos.java
+++ b/app/src/main/java/xyz/cirno/unfuckzui/feature/AllowDisableDolbyAtmos.java
@@ -26,7 +26,7 @@ public class AllowDisableDolbyAtmos {
                         XposedHelpers.callMethod(pref, "setSummary", (Object)null);
                     }
                 });
-            } else if (Build.VERSION.SDK_INT == 35) {
+            } else if (Build.VERSION.SDK_INT == 35 || Build.VERSION.SDK_INT == 36) {
                 XposedHelpers.findAndHookMethod("com.lenovo.settings.sound.dolby.DolbyAtmosUtils", lpparam.classLoader, "isHeadsetConnected", android.content.Context.class, XC_MethodReplacement.returnConstant(Boolean.TRUE));
                 XposedHelpers.findAndHookMethod("com.lenovo.settings.sound.dolby.DolbySwitchPreferenceController", lpparam.classLoader, "updateState", "androidx.preference.Preference", new XC_MethodHook() {
                     @Override


### PR DESCRIPTION
反编译看了android 16 的 zuxos 的设置，发现和 android15 的几乎一致，遂使用原 hook
已在 TB321FU  ZUXOS 1.5.10.184 上通过测试